### PR TITLE
Fix game crash bug

### DIFF
--- a/DiscordSDK/Core.cs
+++ b/DiscordSDK/Core.cs
@@ -1647,8 +1647,10 @@ namespace Discord
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void UpdateActivityCallback(IntPtr ptr, Result result);
 
+            private readonly static FFIMethods.UpdateActivityCallback updateActivityCallback = new FFIMethods.UpdateActivityCallback(UpdateActivityCallbackImpl);
+
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void UpdateActivityMethod(IntPtr methodsPtr, ref Activity activity, IntPtr callbackData, UpdateActivityCallback callback);
+            internal delegate void UpdateActivityMethod(IntPtr methodsPtr, ref Activity activity, IntPtr callbackData, updateActivityCallback callback);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void ClearActivityCallback(IntPtr ptr, Result result);


### PR DESCRIPTION
The Discord SDK has an issue when compiled today where it causes the game using this MelonLoader Plugin to crash with an error:

`Process terminated. A callback was made on a garbage collected delegate of type 'DiscordStatusPlugin!Discord.ActivityManager+FFIMethods+UpdateActivityCallback::Inboke'.`

The issue and workaround implemented were documented here:
https://github.com/discord/gamesdk-and-dispatch/issues/36